### PR TITLE
fix: Remove auto-detection of English language

### DIFF
--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -30,13 +30,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
       if (savedLang && (savedLang === 'is' || savedLang === 'en')) {
         setLanguageState(savedLang);
-      } else {
-        // Auto-detect from browser
-        const browserLang = navigator.language.toLowerCase();
-        if (!browserLang.startsWith('is')) {
-          setLanguageState('en');
-        }
       }
+      // Default language is always Icelandic ('is')
 
       if (savedRegion && savedRegion in REGIONS_INFO) {
         setRegionState(savedRegion);


### PR DESCRIPTION
Fixes #8

The app was automatically switching to English for users with non-Icelandic browser settings. According to CLAUDE.md guidelines, all UI should default to Icelandic.

## Changes
- Removed browser language auto-detection that set English for non-Icelandic browsers
- App now always defaults to Icelandic (`is`)
- Users can still manually select English in settings if needed

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined language preference handling. The language settings no longer attempt automatic browser language detection when a saved preference is unavailable. The application now consistently defaults to Icelandic in these cases, providing more predictable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->